### PR TITLE
Enabling delete of existing indexables as part of indexing tasks.

### DIFF
--- a/search_service/tasks.py
+++ b/search_service/tasks.py
@@ -51,6 +51,7 @@ class BaseSearchServiceIndexingTask(object):
         )
         if indexables_serializer.is_valid():
             logger.info(indexables_serializer.validated_data)
+            self.delete_existing_indexables(instance)
             indexables_serializer.save()
             return indexables_serializer.data
         else:


### PR DESCRIPTION
This ensures that duplicate indexables will not be created as part of SearchServiceIndexingTasks. Any existing indexables for a resource are deleted after the Serializer generating the new indexables from it is confirmed to be valid, and before the new indexables are created.  